### PR TITLE
Move Test::More to be a test.requires only dependency

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,20 +3,32 @@ use ExtUtils::MakeMaker;
 my %opts = (
     'NAME'	   => 'Class::Base',
     'VERSION_FROM' => 'lib/Class/Base.pm',
-    'PREREQ_PM' => {
+    'PREREQ_PM' => { },
+    'TEST_REQUIRES' => {
         'Test::More' => 0.47,
     },
     LICENSE  => 'perl',
     META_MERGE        => {
-       resources => {
-           repository  =>  'https://github.com/szabgab/Class-Base',
-       },
-	},
+        'meta-spec' => { version => 2 },
+        resources   => {
+            repository => {
+                web  => 'https://github.com/szabgab/Class-Base',
+                url  => 'https://github.com/szabgab/Class-Base',
+                type => 'git',
+            },
+        },
+    },
 );
 
 if ($ExtUtils::MakeMaker::VERSION >= 5.43) {
     $opts{ AUTHOR }   = 'Andy Wardley <abw@kfs.org>';
     $opts{ ABSTRACT } = 'useful base class for other modules',
 }
-
+if ($ExtUtils::MakeMaker::VERSION <= 6.64) {
+  if ($ExtUtils::MakeMaker::VERSION >= 6.55_01) {
+    $opts{ BUILD_REQUIRES } = delete $opts{ TEST_REQUIRES };
+  } else {
+    $opts{ PREREQ_PM }      = delete $opts{ TEST_REQUIRES };
+  }
+}
 WriteMakefile( %opts );


### PR DESCRIPTION
This makes the dependency graph smaller for people who use `cpanm
--notest`

Doing so accurately requires META 2.0 specification usage.

By default, EUMM assumes `META_MERGE` is META 1.4 and upgrades it to META
2.0 for `META.json`

Stating `meta-spec.version` in META_MERGE to be 2 tells EUMM to assume
`META_MERGE` is META 2.0 and it then converts that back to 1.4 for
`META.yml` instead ( where test_requires becomes build_requires )

Meta 2.0 Spec however requires stipulating repositories differently.

Additional hedging in `Makefile.PL` is done so legacy installs
that don't support `TEST_REQUIRES` or `BUILD_REQUIRES` and entirely
ignore/misunderstand `META.*` will fallback to assuming `TEST_REQUIRES`
is a runtime requirement ( for which legacy targets have no other
concept )

### Footnote:

I've given more detail than is typically needed here because I couldn't find any blogs covering this, even though I was sure there was one somewhere, and I stumbled into this, which is probably slightly out-of-date with regards to this growing best-practice.

http://perlmaven.com/minimal-requirement-to-build-a-sane-cpan-package 

Though the specifics of merging back the "new" dependency specs into `PREREQ_PM` in legacy compatible ways are very nuanced, and I've not really implemented them fully here, because it wasn't needed ( no runtime requirements means merging is simple, but if you actually have `PREREQ_PM` or `BUILD_REQUIRES`, you should merge their hashes together, and you have to be specifically careful around anything when the same module exists in multiple phases with different versions )




HTH.