### PR TITLE
Correct a typo in POD

### DIFF
--- a/lib/Class/Base.pm
+++ b/lib/Class/Base.pm
@@ -780,7 +780,7 @@ This module began life as the Template::Base module distributed as
 part of the Template Toolkit. 
 
 Thanks to Brian Moseley and Matt Sergeant for suggesting various
-enhancments, some of which went into version 0.02.
+enhancements, some of which went into version 0.02.
 
 Version 0.04 was uploaded by Gabor Szabo.
 


### PR DESCRIPTION
Whilst packaging 0.08 for Debian, we noticed a typo in the POD.

This patch corrects this.